### PR TITLE
feat: fix plugin command name

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -7,7 +7,7 @@ async function clipPage() {
     return;
   }
 
-  const obsidianURI = `obsidian://advanced-uri?vault=${vaultName}&commandname=ReadItLater%3A%20Save%20clipboard`
+  const obsidianURI = `obsidian://advanced-uri?vault=${vaultName}&commandname=ReadItLater%3A%20Create%20from%20clipboard`
 
   browser.tabs.query({currentWindow: true, active: true}).then((tabs) => {
     const { url } = tabs[0];


### PR DESCRIPTION
Hello,

Recently, your Firefox extension stopped working due to the use of a different command when executing `commandname` in advanced-uri.

Could you please review and merge these changes to make the extension work again?

Thank you!